### PR TITLE
ACT-1994: message_key can be nil

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -483,7 +483,7 @@ module OmniAuth
 
     def fail!(message_key, exception = nil)
       env['omniauth.error'] = exception
-      env['omniauth.error.type'] = message_key.to_sym
+      env['omniauth.error.type'] = message_key&.to_sym || :unknown
       env['omniauth.error.strategy'] = self
 
       if exception


### PR DESCRIPTION
There appears to be a case where oidc fails with a nil message_key, obscuring the actual issue from the 
logs. This will hopefully give us more insight into what the actual error is

### References
[Athena Logs](https://secure.aha.io/admin/aha_log_viewer/queries/7517752205294370641?display_time_zone=Central+Time+%28US+%26+Canada%29)
[Sentry error](https://aha-labs-inc.sentry.io/issues/6505025683/?project=139823&query=is%3Aunresolved%20undefined%20method%20%60to_sym%27%20for%20nil&referrer=issue-stream&sort=date&stream_index=0)

- Fixes AHA-PRODUCTION-8GER

* [Support ticket](https://ahasupport.zendesk.com/agent/tickets/1078175)
* [Sentry error](https://aha-labs-inc.sentry.io/issues/6505025683/?project=139823&query=is%3Aunresolved%20undefined%20method%20%60to_sym%27%20for%20nil&referrer=issue-stream&sort=date&stream_index=0)